### PR TITLE
added str_getcsv escape character

### DIFF
--- a/code/traffic.php
+++ b/code/traffic.php
@@ -36,7 +36,7 @@ if (isset($_GET['ajax'])) {
 
 function showrow($row) {
 	global $displayallchannels;
-	$fields=str_getcsv($row,",");
+	$fields=str_getcsv($row,",",escape = "\\");
 	$channel=$fields[0];
 	$timestamp=$fields[2];
     	$source=$fields[3];


### PR DESCRIPTION
As of PHP 8.4.0, depending on the default value of escape is deprecated. It needs to be provided explicitly.